### PR TITLE
vagrant 1.4 is fine too

### DIFF
--- a/packaging/README for Vagrant.md
+++ b/packaging/README for Vagrant.md
@@ -4,7 +4,7 @@ Running in Vagrant
 Pre-requisites:
 
 - [Virtualbox](https://www.virtualbox.org/) 4.0 or greater.
-- [Vagrant](http://www.vagrantup.com/) 1.5 or greater.
+- [Vagrant](http://www.vagrantup.com/) 1.4 or greater.
 
 Clone this project and get it running:
 
@@ -37,4 +37,4 @@ To have your Skype DB files accessible within the VM, place them in project dire
 ---
 
 Vagrant support provided by [Alberto Scotto](https://github.com/alb-i986) 
-and [Elan Ruusamäe](https://github.com/glensc).
+and [Elan Ruusamï¿½e](https://github.com/glensc).


### PR DESCRIPTION
i'm not sure why i wrote 1.5 in 4d3089d, as i myself used 1.4.3 when did the testing. and looking at the current syntax i guess old as 1.1 even can work
